### PR TITLE
Ghidra 11.1 required update and adding Drcov additional support

### DIFF
--- a/data/codecoverage.theme.properties
+++ b/data/codecoverage.theme.properties
@@ -1,8 +1,8 @@
 [Defaults]
 icon.cartographer.plugin.action.show.options = applications-system.png
 icon.cartographer.plugin.action.window = coverage.png
-color.bg.plugin.overview.cartographer.decompiler = rgb(204, 204, 255)
-color.bg.plugin.overview.cartographer.listing = rgb(204, 204, 255)
+color.bg.plugin.overview.cartographer.decompiler = rgb(204, 109, 109)
+color.bg.plugin.overview.cartographer.listing = rgb(204, 109, 109)
 color.bg.plugin.overview.cartographer.high = rgb(51, 153, 255)
 color.bg.plugin.overview.cartographer.low = rgb(255, 51, 51)
 color.bg.plugin.overview.cartographer.none = rgb(51, 51, 51)

--- a/src/main/java/cartographer/CartographerPlugin.java
+++ b/src/main/java/cartographer/CartographerPlugin.java
@@ -67,7 +67,7 @@ import cartographer.CoverageFile.*;
 @PluginInfo(
     status = PluginStatus.RELEASED,
     packageName = MiscellaneousPluginPackage.NAME,
-    category = PluginCategoryNames.DECOMPILER,
+    category = PluginCategoryNames.DIAGNOSTIC,
     shortDescription = "Code coverage parser",
     description = "Plugin for loading and processing code coverage data."
 )

--- a/src/main/java/cartographer/CoverageFile.java
+++ b/src/main/java/cartographer/CoverageFile.java
@@ -293,7 +293,7 @@ public class CoverageFile {
 
         // base is set as size as base was not introduced until version 2 of Drcov module entry
         // likely that this Cartographer does not support V1 of Drcov format.
-        int base = Integer.parseInt(moduleData[1].trim().replace("0x",""), 16);
+        long base = Long.parseUnsignedLong(moduleData[1].trim().replace("0x",""), 16);
 
         String name = moduleData[moduleData.length-1].trim();
 
@@ -313,7 +313,7 @@ public class CoverageFile {
         // parentId is 0 as it was not introduced until version 3 of Drcov module entry
         int parentId = 0;
 
-        int base = Integer.parseInt(moduleData[1].trim().replace("0x",""), 16);
+        long base = Long.parseUnsignedLong(moduleData[1].trim().replace("0x",""), 16);
 
         String name = moduleData[moduleData.length-1].trim();
 
@@ -332,7 +332,7 @@ public class CoverageFile {
 
         int parentId = Integer.parseInt(moduleData[1].trim());
 
-        int base = Integer.parseInt(moduleData[1].trim().replace("0x",""), 16);
+        long base = Long.parseUnsignedLong(moduleData[2].trim().replace("0x",""), 16);
 
         String name = moduleData[moduleData.length-1].trim();
 
@@ -351,7 +351,7 @@ public class CoverageFile {
 
         int parentId = Integer.parseInt(moduleData[1].trim());
 
-        int base = Integer.parseInt(moduleData[1].trim().replace("0x",""), 16);
+        long base = Long.parseUnsignedLong(moduleData[2].trim().replace("0x",""), 16);
 
         String name = moduleData[moduleData.length-1].trim();
 
@@ -370,7 +370,7 @@ public class CoverageFile {
 
         int parentId = Integer.parseInt(moduleData[1].trim());
 
-        int base = Integer.parseInt(moduleData[1].trim().replace("0x",""), 16);
+        long base = Long.parseUnsignedLong(moduleData[2].trim().replace("0x",""), 16);
 
         String name = moduleData[moduleData.length-1].trim();
 
@@ -403,7 +403,7 @@ public class CoverageFile {
 
             // Add each block to the new module
             for (BasicBlock block : module.getBasicBlocks()) {
-                newMod.addBlock(block.offset + module.base, block.size, block.moduleId);
+                newMod.addBlock(block.offset, block.size, block.moduleId);
             }
 
             // Add the new module to the module list
@@ -502,7 +502,7 @@ public class CoverageFile {
 
         private int moduleId;
         private int parentId;
-        private int base;
+        private long base;
         private String name;
 
         /**
@@ -513,7 +513,7 @@ public class CoverageFile {
          * @param base      Base memory address
          * @param name      Name of the file
          */
-        public DrCovModule(int moduleId, int parentId, int base, String name) {
+        public DrCovModule(int moduleId, int parentId, long base, String name) {
             this.moduleId = moduleId;
             this.parentId = parentId;
             this.base = base;

--- a/src/main/java/cartographer/CoverageFile.java
+++ b/src/main/java/cartographer/CoverageFile.java
@@ -313,7 +313,7 @@ public class CoverageFile {
         // parentId is 0 as it was not introduced until version 3 of Drcov module entry
         int parentId = 0;
 
-        int base = 0;
+        int base = Integer.parseInt(moduleData[1].trim().replace("0x",""), 16);
 
         String name = moduleData[moduleData.length-1].trim();
 


### PR DESCRIPTION
Requesting this to be merged in as Cartographer cannot currently be built for Ghidra 11.1 with the removal of the DECOMPILER PluginCategoryNames.

This pull request also includes support for Drcov versions from 2 through 5; based on the lighthouse tool https://github.com/gaasedelen/lighthouse/blob/562595be9bd99e8a5dfef6017d608467f5706630/plugins/lighthouse/reader/parsers/drcov.py#L413

I am curious why the base is required when Ghidra sets it to 0? I had to change the base to 0 for drcov v2 to have the log files load properly - perhaps this is required for all Drcov versions? Happy to make the change to the pull request.