### PR TITLE
Use SimpleBlockModel instead of BasicBlockModel for coverage blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.gradle
+build
+dist

--- a/src/main/java/cartographer/CartographerPlugin.java
+++ b/src/main/java/cartographer/CartographerPlugin.java
@@ -67,7 +67,7 @@ import cartographer.CoverageFile.*;
 @PluginInfo(
     status = PluginStatus.RELEASED,
     packageName = MiscellaneousPluginPackage.NAME,
-    category = PluginCategoryNames.DECOMPILER,
+    category = PluginCategoryNames.DIAGNOSTIC,
     shortDescription = "Code coverage parser",
     description = "Plugin for loading and processing code coverage data."
 )

--- a/src/main/java/cartographer/CoverageFunction.java
+++ b/src/main/java/cartographer/CoverageFunction.java
@@ -21,6 +21,7 @@ import ghidra.program.model.address.AddressRange;
 import ghidra.program.model.address.AddressSet;
 import ghidra.program.model.address.AddressSetView;
 import ghidra.program.model.block.BasicBlockModel;
+import ghidra.program.model.block.SimpleBlockModel;
 import ghidra.program.model.block.CodeBlock;
 import ghidra.program.model.block.CodeBlockIterator;
 import ghidra.program.model.block.CodeBlockModel;
@@ -111,7 +112,7 @@ public class CoverageFunction {
         instructionsHit = 0;
 
         Program fnProgram = function.getProgram();
-        CodeBlockModel blockModel = new BasicBlockModel(fnProgram);
+        CodeBlockModel blockModel = new SimpleBlockModel(fnProgram);
 
         AddressSetView body = function.getBody();
 


### PR DESCRIPTION
The [BasicBlockModel](https://ghidra.re/ghidra_docs/api/ghidra/program/model/block/BasicBlockModel.html) does not split basic blocks on instruction that branch outside of the function (i.e. calls). This can lead to instructions being highlighted even if they are not covered, usually when a called function never returns. Ghidra offers the [SimpleBlockModel](https://ghidra.re/ghidra_docs/api/ghidra/program/model/block/SimpleBlockModel.html), which is a drop-in replacement (also implements the `CodeBlockModel` interface) and splits blocks on all flow-breaking instructions.
Below, I have an example where I loaded a coverage file for an ARM binary, with only the basic block at `36c` of length 1 being covered.

Current state using BasicBlockModel, coverage is extended beyond the `memset` call
![cartographer_bbm](https://github.com/nccgroup/Cartographer/assets/25135999/c739731c-4259-42a0-8fa6-666e055678ae)

Coverage using SimpleBlockModel, coverage is not extended beyond the `memset` call
![cartographer_sbm](https://github.com/nccgroup/Cartographer/assets/25135999/a7886558-71cb-4802-9f09-e878d7e42ffe)
