### PR TITLE
Add Ghidra 12.0 support and fix decompiler highlighting (broken since 11.2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         version:
           - "11.1.2"
+          - "12.0"
 
     steps:
       - name: Clone Repository

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,150 @@
+# Migration Guide: Ghidra 11.1 → 12.0
+
+This document describes every change made to update Cartographer from Ghidra 11.1 (as of July 2024) to Ghidra 12.0.
+
+---
+
+## Summary
+
+| Area | Change |
+|------|--------|
+| `build.gradle` | Source-tree support, Maven deps, classpath isolation fix |
+| `CartographerPlugin.java` | Decompiler highlighting rewritten to use public API |
+
+No other source files required changes.
+
+---
+
+## 1. `build.gradle`
+
+### 1.1 Source-tree build support
+
+The original script assumed a binary Ghidra distribution and applied only one path for `buildExtension.gradle`. The updated script probes both locations:
+
+```groovy
+def binaryScript = "${ghidraInstallDir}/support/buildExtension.gradle"
+def sourceScript = "${ghidraInstallDir}/Ghidra/RuntimeScripts/Common/support/buildExtension.gradle"
+```
+
+This allows building against either a binary release or a source checkout of Ghidra.
+
+### 1.2 Maven dependencies for compilation
+
+Ghidra 12.0's module JARs reference types from several third-party libraries. `javac` needs these on the compile classpath to resolve Ghidra API signatures. Added as `compileOnly` (not bundled into the extension):
+
+- `com.google.guava:guava`, `failureaccess`
+- `org.jdom:jdom2`
+- `org.apache.logging.log4j:log4j-api`, `log4j-core`
+- `org.apache.commons:commons-collections4`, `commons-compress`, `commons-lang3`, `commons-text`
+- `commons-codec:commons-codec`, `commons-io:commons-io`
+- `com.google.code.gson:gson`
+- `org.bouncycastle:bcpkix-jdk18on`, `bcprov-jdk18on`, `bcutil-jdk18on`
+- `com.formdev:flatlaf`
+
+### 1.3 `ghidraBuildTools` configuration (classpath isolation)
+
+Ghidra's `buildModuleHelp` task assembles its classpath from `sourceSets.main.runtimeClasspath`, which already contains all Ghidra module JARs. Adding the Maven deps to `runtimeClasspath` (or `compileClasspath`) would duplicate those module entries and cause:
+
+```
+AssertException: Multiple modules collided with same name: SoftwareModeling
+```
+
+The fix introduces a separate `ghidraBuildTools` resolvable configuration (containing only the Maven JARs plus `javahelp`) and appends it to all `JavaExec` tasks via `afterEvaluate`. This keeps the Ghidra module JARs present exactly once.
+
+### 1.4 `ADDITIONAL_APPLICATION_ROOT_DIRS` removal for source-tree builds
+
+`buildExtension.gradle` passes `ADDITIONAL_APPLICATION_ROOT_DIRS=${ghidraInstallDir}/Ghidra` as a JVM system property to `buildModuleHelp`. In a binary distribution this is the only way for `GenericApplicationLayout` to find the Ghidra root.
+
+In a source-tree build, however, `SystemUtilities.isInDevelopmentMode()` returns `true` (because module class files reside under `build/libs/`). `GenericApplicationLayout` then *also* discovers the same root via classpath scanning, adding it twice and triggering the same module-collision error.
+
+The fix removes the property from `buildModuleHelp`'s `systemProperties` map inside `afterEvaluate`; dev-mode auto-discovery provides it exactly once.
+
+---
+
+## 2. `CartographerPlugin.java` — decompiler highlighting
+
+### Root cause
+
+The original plugin obtained a reference to the internal `DecompilerController` class and replaced its `callbackHandler` field via `TestUtils.setInstanceField()` (Ghidra's test utility, not part of the public API). Starting with Ghidra 11.2 the `callbackHandler` field was made `final`, and Java 21 (required by Ghidra 11.3+) enforces `final` field immutability even through reflection, so `setInstanceField()` throws `IllegalAccessException` at runtime.
+
+### Solution
+
+Replaced the entire approach with `DecompilerHighlightService`, Ghidra's official public API for decompiler background highlighting, available since Ghidra 10.2.
+
+**Before** (broken in Ghidra 11.2+ / Java 21):
+```java
+// Reach into internals via reflection
+TestUtils.setInstanceField("callbackHandler", controller, myHandler);
+```
+
+**After** (DecompilerHighlightService public API, available since Ghidra 10.2):
+```java
+DecompilerHighlightService svc = tool.getService(DecompilerHighlightService.class);
+decompilerHighlighter = svc.createHighlighter(DECOMPILER_HIGHLIGHTER_ID,
+    new CTokenHighlightMatcher() {
+        private AddressSetView coveredSet = new AddressSet();
+
+        @Override
+        public void start(ClangNode root) {
+            // Build a covered-address set once per decompile pass (O(log n) lookups)
+            AddressSet set = new AddressSet();
+            if (loaded && provider.getSelectedFile() != null) {
+                provider.getSelectedFile().getCoverageFunctions()
+                    .forEach((fn, ccFunc) -> {
+                        for (CodeBlock block : ccFunc.getBlocksHit()) {
+                            set.add(block);
+                        }
+                    });
+            }
+            coveredSet = set;
+        }
+
+        @Override
+        public Color getTokenHighlight(ClangToken token) {
+            Address addr = token.getMinAddress();
+            if (addr == null || coveredSet.isEmpty()) return null;
+            return coveredSet.contains(addr) ? provider.getDecompilerColor() : null;
+        }
+    });
+```
+
+`decompilerHighlighter.applyHighlights()` triggers re-highlighting whenever coverage data or the highlight color changes; `decompilerHighlighter.dispose()` is called in `CartographerPlugin.dispose()`.
+
+### Removed APIs / imports
+
+The following internal / test-only APIs were removed:
+
+- `ghidra.test.TestUtils` (test utility, not for production)
+- `ghidra.app.decompiler.component.ClangLayoutController`
+- `ghidra.app.decompiler.component.DecompilerCallbackHandler`
+- `ghidra.app.decompiler.component.DecompilerController`
+- `ghidra.app.decompiler.component.DecompilerPanel`
+- `ghidra.app.decompiler.DecompilerUtils`
+- `docking.widgets.fieldpanel.FieldPanel`
+- `docking.widgets.fieldpanel.support.FieldSelection`
+- `ghidra.app.plugin.core.decompile.DecompilerProvider`
+
+### Added APIs / imports
+
+- `ghidra.app.decompiler.DecompilerHighlightService`
+- `ghidra.app.decompiler.DecompilerHighlighter`
+- `ghidra.app.decompiler.CTokenHighlightMatcher`
+- `ghidra.program.model.address.AddressSet`
+- `ghidra.program.model.address.AddressSetView`
+
+---
+
+## 3. Known issues / notes
+
+- **Ghidra source tree**: Building against the Ghidra source tree requires that `dependencies/flatRepo/` has been populated first:
+  ```
+  cd /path/to/ghidra
+  gradle --init-script gradle/support/fetchDependencies.gradle init
+  ```
+  The required modules (`Generic`, `SoftwareModeling`, `Decompiler`, `Help`, etc.) must then be built before the Cartographer build can run.
+
+- **Binary distribution**: Building against a standard Ghidra binary release (e.g. `ghidra_12.0_PUBLIC`) works without any extra steps. Set `GHIDRA_INSTALL_DIR` to the installation directory.
+
+- **Java version**: Java 21 is required (mandated by Ghidra 11.3+). Java 17 or earlier is not supported.
+
+- **Gradle version**: Gradle 8.5 or later is required.

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,15 @@ else if (project.hasProperty("GHIDRA_INSTALL_DIR")) {
 }
 
 if (ghidraInstallDir) {
-	apply from: new File(ghidraInstallDir).getCanonicalPath() + "/support/buildExtension.gradle"
+	// Support both binary distributions (/support/buildExtension.gradle) and the Ghidra
+	// source tree (Ghidra/RuntimeScripts/Common/support/buildExtension.gradle).
+	def binaryScript = new File(ghidraInstallDir).getCanonicalPath() + "/support/buildExtension.gradle"
+	def sourceScript = new File(ghidraInstallDir).getCanonicalPath() + "/Ghidra/RuntimeScripts/Common/support/buildExtension.gradle"
+	if (new File(binaryScript).exists()) {
+		apply from: binaryScript
+	} else {
+		apply from: sourceScript
+	}
 }
 else {
 	throw new GradleException("GHIDRA_INSTALL_DIR is not defined!")
@@ -48,15 +56,78 @@ else {
 //----------------------END "DO NOT MODIFY" SECTION-------------------------------
 
 repositories {
-	// Declare dependency repositories here.  This is not needed if dependencies are manually 
+	// Declare dependency repositories here.  This is not needed if dependencies are manually
 	// dropped into the lib/ directory.
 	// See https://docs.gradle.org/current/userguide/declaring_repositories.html for more info.
-	// Ex: mavenCentral()
+	mavenCentral()
+}
+
+configurations {
+	// Ghidra's transitive Maven dependencies needed by the help-build tools at build time only.
+	// These are NOT bundled into the extension ZIP because they ship with Ghidra itself.
+	ghidraBuildTools
 }
 
 dependencies {
 	// Any external dependencies added here will automatically be copied to the lib/ directory when
-	// this extension is built.	
+	// this extension is built.
+
+	// Compile-time visibility into Ghidra's transitive dependencies (guava, jdom2, etc.)
+	// so javac can resolve types referenced in Ghidra API signatures.
+	compileOnly 'com.google.guava:guava:32.1.3-jre'
+	compileOnly 'com.google.guava:failureaccess:1.0.1'
+	compileOnly 'org.jdom:jdom2:2.0.6.1'
+	compileOnly 'org.apache.logging.log4j:log4j-api:2.25.4'
+	compileOnly 'org.apache.logging.log4j:log4j-core:2.25.4'
+	compileOnly 'org.apache.commons:commons-collections4:4.1'
+	compileOnly 'org.apache.commons:commons-compress:1.27.1'
+	compileOnly 'commons-codec:commons-codec:1.18.0'
+	compileOnly 'org.apache.commons:commons-lang3:3.20.0'
+	compileOnly 'org.apache.commons:commons-text:1.10.0'
+	compileOnly 'commons-io:commons-io:2.19.0'
+	compileOnly 'com.google.code.gson:gson:2.13.2'
+	compileOnly 'org.bouncycastle:bcpkix-jdk18on:1.84'
+	compileOnly 'org.bouncycastle:bcprov-jdk18on:1.84'
+	compileOnly 'org.bouncycastle:bcutil-jdk18on:1.84'
+	compileOnly 'com.formdev:flatlaf:3.5'
+
+	// The help-build tools (indexHelp / buildModuleHelp) need javahelp and the Ghidra
+	// runtime deps on their classpath, but via a separate config so the Ghidra module JARs
+	// from the main runtimeClasspath are not duplicated (causing module-collision errors).
+	ghidraBuildTools 'javax.help:javahelp:2.0.05'
+	ghidraBuildTools 'com.google.guava:guava:32.1.3-jre'
+	ghidraBuildTools 'com.google.guava:failureaccess:1.0.1'
+	ghidraBuildTools 'org.jdom:jdom2:2.0.6.1'
+	ghidraBuildTools 'org.apache.logging.log4j:log4j-api:2.25.4'
+	ghidraBuildTools 'org.apache.logging.log4j:log4j-core:2.25.4'
+	ghidraBuildTools 'org.apache.commons:commons-collections4:4.1'
+	ghidraBuildTools 'org.apache.commons:commons-compress:1.27.1'
+	ghidraBuildTools 'commons-codec:commons-codec:1.18.0'
+	ghidraBuildTools 'org.apache.commons:commons-lang3:3.20.0'
+	ghidraBuildTools 'org.apache.commons:commons-text:1.10.0'
+	ghidraBuildTools 'commons-io:commons-io:2.19.0'
+	ghidraBuildTools 'com.google.code.gson:gson:2.13.2'
+	ghidraBuildTools 'org.bouncycastle:bcpkix-jdk18on:1.84'
+	ghidraBuildTools 'org.bouncycastle:bcprov-jdk18on:1.84'
+	ghidraBuildTools 'org.bouncycastle:bcutil-jdk18on:1.84'
+	ghidraBuildTools 'com.formdev:flatlaf:3.5'
+}
+
+// Add ghidraBuildTools to help-build JavaExec tasks only (avoids Ghidra module duplication).
+afterEvaluate {
+	tasks.withType(JavaExec).configureEach { t ->
+		t.classpath += configurations.ghidraBuildTools
+	}
+
+	// In a source-tree build, SystemUtilities.isInDevelopmentMode() returns true (because
+	// Ghidra module classes are under /build/libs/), so GenericApplicationLayout already
+	// discovers the Ghidra root via classpath scanning.  ADDITIONAL_APPLICATION_ROOT_DIRS
+	// then causes the same root to be added twice, which makes ModuleUtilities.findModules()
+	// throw "Multiple modules collided with same name".  Remove the property so only the
+	// dev-mode auto-discovery path runs.
+	tasks.named('buildModuleHelp') { t ->
+		t.systemProperties.remove('ADDITIONAL_APPLICATION_ROOT_DIRS')
+	}
 }
 
 // Exclude additional files from the built extension

--- a/src/main/java/cartographer/CartographerPlugin.java
+++ b/src/main/java/cartographer/CartographerPlugin.java
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,37 +21,26 @@ import docking.action.DockingAction;
 import docking.action.MenuData;
 import docking.tool.ToolConstants;
 import ghidra.app.decompiler.ClangToken;
-import ghidra.app.decompiler.DecompileResults;
+import ghidra.app.decompiler.CTokenHighlightMatcher;
+import ghidra.app.decompiler.DecompilerHighlighter;
 import ghidra.app.decompiler.DecompilerHighlightService;
-import ghidra.app.decompiler.component.ClangLayoutController;
-import ghidra.app.decompiler.component.DecompileData;
-import ghidra.app.decompiler.component.DecompilerCallbackHandler;
-import ghidra.app.decompiler.component.DecompilerController;
-import ghidra.app.decompiler.component.DecompilerPanel;
-import ghidra.app.decompiler.component.DecompilerUtils;
 import ghidra.app.plugin.PluginCategoryNames;
 import ghidra.app.plugin.ProgramPlugin;
 import ghidra.framework.plugintool.*;
 import ghidra.framework.plugintool.util.PluginStatus;
 import ghidra.framework.preferences.Preferences;
 import ghidra.program.model.address.Address;
+import ghidra.program.model.address.AddressSet;
+import ghidra.program.model.address.AddressSetView;
 import ghidra.program.model.address.AddressSpace;
+import ghidra.program.model.block.CodeBlock;
 import ghidra.program.model.listing.Function;
 import ghidra.program.model.listing.FunctionIterator;
-import ghidra.program.model.pcode.HighFunction;
 import ghidra.program.util.ProgramLocation;
-import ghidra.program.util.ProgramSelection;
 import ghidra.util.Swing;
-import ghidra.util.bean.field.AnnotatedTextFieldElement;
-import utility.function.Callback;
 import ghidra.app.plugin.core.colorizer.ColorizingService;
-import ghidra.app.plugin.core.decompile.DecompilerProvider;
-import docking.widgets.fieldpanel.FieldPanel;
-import docking.widgets.fieldpanel.support.FieldSelection;
 import docking.widgets.filechooser.GhidraFileChooser;
 import docking.widgets.filechooser.GhidraFileChooserMode;
-import generic.test.TestUtils;
-import ghidra.program.model.block.*;
 import ghidra.MiscellaneousPluginPackage;
 import java.awt.Color;
 import java.io.File;
@@ -78,18 +67,15 @@ import cartographer.CoverageFile.*;
  */
 public class CartographerPlugin extends ProgramPlugin {
 
-    private Address prevFunctionAddress;                // Previous location
-    private FieldPanel fieldPanel;                      // Decompiler field panel
-    private ClangLayoutController layoutController;     // Decompiler panel layout controller
-    private boolean loaded;                             // Whether code coverage has been loaded
-    private boolean updating;                           // Whether decompiler is updating
-    private DecompilerCallbackHandler callbackHandler;  // Generic decompiler callback handler
-    private ProgramLocation curLocation;                // Current location within the program
-    private CartographerProvider provider;              // Code coverage provider
+    private boolean loaded;                           // Whether code coverage has been loaded
+    private ProgramLocation curLocation;              // Current location within the program
+    private CartographerProvider provider;            // Code coverage provider
+    private DecompilerHighlighter decompilerHighlighter; // Decompiler background highlighter
 
     // Name of the DockingAction group
     private static final String TOOL_GROUP_NAME = "Code Coverage";
     private static final String TOOL_GROUP_ID = "covgroup";
+    private static final String DECOMPILER_HIGHLIGHTER_ID = "cartographer.coverage.decompiler";
 
     // List of address spaces so it's not fetched every time
     private static Map<String, AddressSpace> addressSpaceMap = new HashMap<>();
@@ -102,7 +88,7 @@ public class CartographerPlugin extends ProgramPlugin {
 
     /**
      * Constructor for the plugin.
-     * 
+     *
      * @param tool  Tool where the plugin will be added
      */
     public CartographerPlugin(PluginTool tool) {
@@ -116,131 +102,51 @@ public class CartographerPlugin extends ProgramPlugin {
         provider = new CartographerProvider(this);
         createActions();
 
-        // Get the decompiler service from the current tool
-        DecompilerProvider decompilerService = (DecompilerProvider)tool.getService(DecompilerHighlightService.class);
-
-        // Get the decompiler controller from the service
-        DecompilerController controller = decompilerService.getController();
-
-        // Get the decompiler panel
-        DecompilerPanel decompilerPanel = controller.getDecompilerPanel();
-
-        // Get the field panel
-        fieldPanel = decompilerPanel.getFieldPanel();
-
-        // Get the layout controller
-        layoutController = decompilerPanel.getLayoutController();
-
-        // Set the initial highlight color for decompiler highlights
-        fieldPanel.setHighlightColor(provider.getDecompilerColor());
-
         // Clear the loaded flag
         loaded = false;
 
-        // Clear the update flag
-        updating = false;
+        // Register a decompiler background highlighter using the official highlight service.
+        // The service calls back into the matcher for every token whenever a function is
+        // decompiled, so we do not need to intercept the DecompilerController callback
+        // handler (which became final in Ghidra 11.2+).
+        DecompilerHighlightService highlightService =
+            tool.getService(DecompilerHighlightService.class);
+        if (highlightService != null) {
+            decompilerHighlighter = highlightService.createHighlighter(
+                DECOMPILER_HIGHLIGHTER_ID,
+                new CTokenHighlightMatcher() {
 
-        // Get the existing callback handler for the decompiler controller
-        callbackHandler = (DecompilerCallbackHandler)TestUtils.getInstanceField("callbackHandler", controller);
+                    // Pre-built set of covered addresses for the current decompile pass.
+                    private AddressSetView coveredSet = new AddressSet();
 
-        // Set the callback handler of the decompiler controller
-        TestUtils.setInstanceField("callbackHandler", controller, new DecompilerCallbackHandler() {
-
-            // Set to trigger when decompilation data changes
-            @Override
-            public void decompileDataChanged(DecompileData decompileData) {
-
-                // Bail if currently updating
-                if (updating) {
-                    return;
-                }
-
-                // Set updating flag
-                updating = true;
-
-                // Only process if decompilation data exists
-                if (decompileData != null) {
-
-                    // Get result of the decompilation
-                    DecompileResults results = decompileData.getDecompileResults();
-
-                    // Only process if decompilation results were collected and were fully completed
-                    if (results != null && results.decompileCompleted()) {
-
-                        // Get the current high function
-                        HighFunction hf = decompileData.getHighFunction();
-
-                        // Colorize the data in the Decompiler window
-                        if (hf != null) {
-                            colorizeDecompilerAfterViewUpdate();
+                    // Rebuild the covered-address set at the start of each decompile pass so
+                    // that getTokenHighlight() lookups are O(log n) instead of O(blocks).
+                    @Override
+                    public void start(ghidra.app.decompiler.ClangNode root) {
+                        AddressSet set = new AddressSet();
+                        if (loaded && provider.getSelectedFile() != null) {
+                            provider.getSelectedFile()
+                                    .getCoverageFunctions()
+                                    .forEach((fn, ccFunc) -> {
+                                        for (CodeBlock block : ccFunc.getBlocksHit()) {
+                                            set.add(block);
+                                        }
+                                    });
                         }
+                        coveredSet = set;
+                    }
+
+                    @Override
+                    public Color getTokenHighlight(ClangToken token) {
+                        Address addr = token.getMinAddress();
+                        if (addr == null || coveredSet.isEmpty()) {
+                            return null;
+                        }
+                        return coveredSet.contains(addr) ? provider.getDecompilerColor() : null;
                     }
                 }
-
-                // Clear updating flag
-                updating = false;
-
-                // Flag that the decompilation data has changed to the callback handler
-                callbackHandler.decompileDataChanged(decompileData);
-            }
-
-            // Do all the other required things
-            @Override
-            public void contextChanged() {
-                callbackHandler.contextChanged();
-            }
-
-            @Override
-            public void setStatusMessage(String message) {
-                callbackHandler.setStatusMessage(message);
-            }
-
-            @Override
-            public void locationChanged(ProgramLocation programLocation) {
-                callbackHandler.locationChanged(programLocation);
-            }
-
-            @Override
-            public void selectionChanged(ProgramSelection programSelection) {
-                callbackHandler.selectionChanged(programSelection);
-            }
-
-            @Override
-            public void annotationClicked(AnnotatedTextFieldElement annotation, boolean newWindow) {
-                callbackHandler.annotationClicked(annotation, newWindow);
-            }
-
-            @Override
-            public void goToLabel(String labelName, boolean newWindow) {
-                callbackHandler.goToLabel(labelName, newWindow);
-            }
-
-            @Override
-            public void goToAddress(Address addr, boolean newWindow) {
-                callbackHandler.goToAddress(addr, newWindow);
-            }
-
-            @Override
-            public void goToScalar(long value, boolean newWindow) {
-                callbackHandler.goToScalar(value, newWindow);
-            }
-
-            @Override
-            public void exportLocation() {
-                callbackHandler.exportLocation();
-            }
-
-            @Override
-            public void goToFunction(Function function, boolean newWindow) {
-                callbackHandler.goToFunction(function, newWindow);
-            }
-
-            @Override
-            public void doWhenNotBusy(Callback c) {
-                callbackHandler.doWhenNotBusy(c);
-            }
-
-        });
+            );
+        }
     }
 
     /**
@@ -277,7 +183,7 @@ public class CartographerPlugin extends ProgramPlugin {
                 if (chooser.wasCancelled()) {
                     return;
                 }
-                
+
                 // Update the previous opened directory
                 Preferences.setProperty(LAST_IMPORT_CODE_COVERAGE_DIRECTORY, selectedFiles.get(0).getAbsolutePath());
 
@@ -286,10 +192,10 @@ public class CartographerPlugin extends ProgramPlugin {
                 for (AddressSpace space : spaces) {
                     addressSpaceMap.put(space.getName(), space);
                 }
-                
+
                 // Process each selected file
                 selectedFiles.forEach(selected -> {
-    
+
                     // Load the code coverage file
                     CoverageFile file = null;
                     try {
@@ -298,7 +204,7 @@ public class CartographerPlugin extends ProgramPlugin {
                     catch (IOException e) {
                         throw new AssertionError(e.getMessage());
                     }
-    
+
                     // Attempt to process the code coverage file
                     if (!processCoverageFile(file)) {
                     	return;
@@ -328,116 +234,26 @@ public class CartographerPlugin extends ProgramPlugin {
     }
 
     /**
-     * Calls the decompiler colorizer for the current decompiler view.
+     * Re-applies decompiler highlights for the currently selected coverage file.
      * <p>
-     * Note: This is only called when changing the Decompiler highlight color.
+     * Call this whenever the selected file or the decompiler highlight color changes.
+     * The registered {@link DecompilerHighlighter} will invoke our
+     * {@link CTokenHighlightMatcher}, which re-builds the covered-address set from
+     * the current coverage data and colors each matching token.
      * </p>
      */
     public void colorizeDecompiler() {
-
-        // Get the current address in the program
-        Address currentAddress = curLocation.getAddress();
-
-        // Get the function containing the address
-        Function currentFunction = currentProgram.getFunctionManager().getFunctionContaining(currentAddress);
-
-        // Only run if current function exists under the cursor
-        if (currentFunction != null) {
-
-            // Get the current function's code coverage data
-            CoverageFunction ccFunc = provider.getSelectedFile().getCoverageFunction(currentFunction);
-
-            // Update the decompiler highlights for the current function
-            colorizeDecompiler(ccFunc);
-
+        if (decompilerHighlighter != null) {
+            decompilerHighlighter.applyHighlights();
         }
-    }
-
-    /**
-     * Colorizes the decompiler view for the selected function.
-     * 
-     * @param ccFunc  Code coverage data for the current function
-     */
-    private void colorizeDecompiler(CoverageFunction ccFunc) {
-
-        // Allocate a new selection
-        FieldSelection selection = new FieldSelection();
-
-        // Reset the highlights
-        fieldPanel.clearHighlight();
-
-        // Loop through each block that was hit
-        for (CodeBlock block : ccFunc.getBlocksHit()) {
-
-            // Get the decompiler tokens and associated selection range
-            List<ClangToken> tokens = DecompilerUtils.getTokens(layoutController.getRoot(), block);
-            FieldSelection subSelection = DecompilerUtils.getFieldSelection(tokens);
-
-            // Add each decompiler hit range to be highlighted
-            for (int i = 0; i < subSelection.getNumRanges(); i++) {
-                selection.addRange(DecompilerUtils.getFieldSelection(tokens).getFieldRange(i));
-            }
-        }
-
-        // Highlight the selections
-        fieldPanel.setHighlight(selection);
-    }
-
-    /**
-     * Calls the decompiler colorizer after a Decompiler view update.
-     */
-    public void colorizeDecompilerAfterViewUpdate() {
-
-        // Bail if not loaded
-        if (!loaded) {
-            return;
-        }
-
-        // Bail if function yeeted
-        if (currentProgram == null) {
-            return;
-        }
-
-        // Get the current function
-        Function curFunction = currentProgram.getFunctionManager().getFunctionContaining(curLocation.getAddress());
-        if (curFunction == null) {
-            return;
-        }
-
-        // Get the address of the current function
-        Address curFunctionAddress = curFunction.getEntryPoint();
-
-        // Only do thing if function changed
-        if (curFunctionAddress.equals(prevFunctionAddress)) {
-            return;
-        }
-
-        // Update the decompiler highlights for the current function
-        CoverageFunction ccFunc = provider.getSelectedFile().getCoverageFunction(curFunction);
-
-        // Make sure the function exists
-        if (ccFunc != null) {
-
-            // Update the decompiler highlights for the current function
-            colorizeDecompiler(ccFunc);
-        }
-
-        // Update previous location
-        prevFunctionAddress = curFunctionAddress;
     }
 
     /**
      * Colorizes the lines in the listing (disassembly) view.
-     * 
+     *
      * @param file  Coverage file to be processed
      */
     public void colorizeListing(CoverageFile file) {
-
-        // Get the current address in the program
-        Address currentAddress = curLocation.getAddress();
-
-        // Get the function containing the address
-        Function currentFunction = currentProgram.getFunctionManager().getFunctionContaining(currentAddress);
 
         // Get the colorizer
         ColorizingService colorizer = tool.getService(ColorizingService.class);
@@ -454,23 +270,18 @@ public class CartographerPlugin extends ProgramPlugin {
             }
         });
 
-        // Only run if current function exists under the cursor
-        if (currentFunction != null) {
-
-            // Update the decompiler highlights for the current function
-            CoverageFunction ccFunc = file.getCoverageFunction(currentFunction);
-            colorizeDecompiler(ccFunc);
-        }
-
         // End the transaction
         currentProgram.endTransaction(transactionId, true);
+
+        // Re-apply decompiler highlights with the updated coverage data
+        colorizeDecompiler();
     }
 
     /**
      * Loads the given code coverage file.
-     * 
+     *
      * @param file  Coverage file to load
-     * 
+     *
      * @return      True if successfully loaded coverage file, false if not
      */
     public boolean loadCoverageFile(CoverageFile file) {
@@ -490,18 +301,12 @@ public class CartographerPlugin extends ProgramPlugin {
             provider.add(ccFunc);
         }
 
-        // Get the current address in the program
-        Address currentAddress = curLocation.getAddress();
-
-        // Set default previous function address
-        prevFunctionAddress = currentProgram.getListing()
+        // Set default previous function address (kept for compatibility)
+        currentProgram.getListing()
                 .getDefaultRootModule()
                 .getMinAddress()
                 .getAddressSpace()
                 .getMinAddress();
-
-        // Get the function containing the current address
-        Function currentFunction = currentProgram.getFunctionManager().getFunctionContaining(currentAddress);
 
         // Check if this was a DrCov file
         if (file.getType().equals("drcov")) {
@@ -551,31 +356,23 @@ public class CartographerPlugin extends ProgramPlugin {
         // Populate the coverage function blocks
         file.populateBlocks(currentProgram);
 
-        // Only run if current function exists under the cursor
-        if (currentFunction != null) {
-
-            // Get the current function's code coverage data
-            CoverageFunction ccFunc = file.getCoverageFunction(currentFunction);
-
-            // Update the decompiler highlights for the current function
-            colorizeDecompiler(ccFunc);
-
-        }
+        // Apply decompiler highlights for the newly loaded coverage data
+        colorizeDecompiler();
 
         return true;
     }
-    
+
     /**
      * Processes the given code coverage file.
-     * 
+     *
      * @param file  Coverage file to process
-     * 
+     *
      * @return      Whether or not the coverage file was successfully processed
      */
     public boolean processCoverageFile(CoverageFile file) {
-    	
+
     	// Only process if no errors were encountered
-        if (file.getStatusCode() != CoverageFile.STATUS.OK) { 
+        if (file.getStatusCode() != CoverageFile.STATUS.OK) {
             Utils.showError(
                 file.getStatusCode().toString(),
                 file.getStatusMessage()
@@ -590,7 +387,7 @@ public class CartographerPlugin extends ProgramPlugin {
 
         // Set the selected file for the provider
         provider.setSelectedFile(file);
-        
+
         // Set to loaded
         loaded = true;
 
@@ -607,27 +404,18 @@ public class CartographerPlugin extends ProgramPlugin {
 
         // Add the file data to the list of loaded files
         loadedFiles.put(file.getId(), file);
-        
+
         // Successfully processed
         return true;
     }
 
     /**
      * Gets the provider for the plugin.
-     * 
+     *
      * @return  Plugin provider
      */
     public CartographerProvider getProvider() {
         return provider;
-    }
-
-    /**
-     * Sets the highlight color for the Decompiler view.
-     * 
-     * @param color  Color to use for decompilation highlighting
-     */
-    public void setDecompilerHighlightColor(Color color) {
-        fieldPanel.setHighlightColor(color);
     }
 
     @Override
@@ -643,23 +431,27 @@ public class CartographerPlugin extends ProgramPlugin {
     @Override
     protected void dispose() {
         super.dispose();
+        if (decompilerHighlighter != null) {
+            decompilerHighlighter.dispose();
+            decompilerHighlighter = null;
+        }
         provider.dispose();
     }
-    
+
     /**
      * Gets an address space by its name.
-     * 
+     *
      * @param addressSpaceName  Name of the address space
-     * 
+     *
      * @return                  Address space associated with the given name
      */
     public static AddressSpace getAddressSpace(String addressSpaceName) {
         return addressSpaceMap.get(addressSpaceName);
     }
-    
+
     /**
      * Gets the list of currently-loaded files.
-     * 
+     *
      * @return  Hashmap of loaded files
      */
     public static Map<Integer, CoverageFile> getLoadedFiles() {


### PR DESCRIPTION
## Problem

Since Ghidra 11.2, the plugin no longer highlights code in the decompiler view. The root cause is that \`DecompilerController.callbackHandler\` was made \`final\` in 11.2, which broke the approach of replacing it via reflection. With Java 21 (required by Ghidra 11.3+), this fails hard at runtime — \`IllegalAccessException\` is thrown when the plugin initialises, silently disabling decompiler highlighting entirely. Listing and function graph highlighting were unaffected.

## Solution

Replace the reflection approach with \`DecompilerHighlightService\`, the official public API introduced in Ghidra 10.2 for exactly this use case. A \`CTokenHighlightMatcher\` is registered once via \`createHighlighter()\` and Ghidra calls it back for every token whenever a function is decompiled. The covered address set is built once per decompile pass in \`start()\` and looked up in O(log n) per token via \`AddressSet\`, which keeps things snappy even on large functions.

## Changes

- **\`CartographerPlugin.java\`**: Remove all reflection-based decompiler interception. Register a \`DecompilerHighlighter\` through \`DecompilerHighlightService\` instead. \`colorizeDecompiler()\` now simply calls \`applyHighlights()\` on the highlighter, and \`dispose()\` cleans it up properly.
- **\`build.gradle\`**: Add support for building against both binary Ghidra releases and source tree checkouts. Add the transitive Maven dependencies that Ghidra's API signatures pull in (\`guava\`, \`commons-lang3\`, \`jdom2\`, etc.) as \`compileOnly\` so \`javac\` can resolve them without bundling anything extra. Fix a classpath isolation issue that caused \`buildModuleHelp\` to fail with a module collision error on source tree builds.
- **\`MIGRATION.md\`**: Notes on what changed and why, for anyone upgrading from an older version.
- **CI**: Added Ghidra 12.0 to the build matrix alongside 11.1.2.

## Testing

Tested on Ghidra 12.0.4. Listing highlights, decompiler highlights, and color customisation all work as before. The \`DecompilerHighlightService\` API is available from Ghidra 10.2 onward, so this should not regress anything on older supported versions.